### PR TITLE
Feat/member status modify

### DIFF
--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/controller/ClimbHistoryController.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/controller/ClimbHistoryController.java
@@ -51,7 +51,7 @@ public class ClimbHistoryController {
         // 여기서부터 수정 필요
         Map<String, Object> responseMap = new HashMap<>();
         if (findClimbCheckDTO != null) {
-            responseMap.put("item", findClimbCheckDTO);
+            responseMap.put("member", findClimbCheckDTO);
             responseMessage = "봉우리 완등 인증 완료";
         } else {
             responseMessage = "현재 등산로에 등산 시작 정보가 없습니다.\n 등산완료 인증 실패";

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/controller/ClimbHistoryController.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/controller/ClimbHistoryController.java
@@ -48,7 +48,6 @@ public class ClimbHistoryController {
         String responseMessage = "";
 
 
-        // 여기서부터 수정 필요
         Map<String, Object> responseMap = new HashMap<>();
         if (findClimbCheckDTO != null) {
             responseMap.put("member", findClimbCheckDTO);

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/dto/FindClimbCheckDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/dto/FindClimbCheckDTO.java
@@ -1,6 +1,9 @@
 package com.bughunters.mountainspirit.climbhistory.command.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
+import com.bughunters.mountainspirit.memberrank.command.dto.ResponseMountainRankDTO;
 import lombok.*;
 
 @NoArgsConstructor
@@ -11,7 +14,29 @@ import lombok.*;
 public class FindClimbCheckDTO {
     private LocalDateTime updateTime;
     private LocalDateTime endTime;
+
+    private Long cumId;
+    private String cumNm;
+    private String frtrlId;
+    private String poiId;
     private String frtrlNm;
     private String placeNm;
     private String stateCode;
+
+    private boolean getMountainStamp;
+    private boolean getCourseStamp;
+    private int courseRank;
+    private boolean modifyMyMountainRank;
+    private long memRankId;
+    private String memRankNm;
+
+    private String mountainStampImagePath;
+    private String courseStampImagePath;
+
+    //합산 흭득 점수
+    private int summaryScore;
+
+    //산별 등급 객체 , 현재 회원 등급 정보, 산신령이 변경되면 이전 산신령 회원정보 포함
+    private List<ResponseMountainRankDTO> modifyRanks;
+
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/dto/ResponseRankDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/dto/ResponseRankDTO.java
@@ -1,0 +1,16 @@
+package com.bughunters.mountainspirit.climbhistory.command.dto;
+
+import com.bughunters.mountainspirit.memberrank.command.dto.ResponseMountainRankDTO;
+import com.bughunters.mountainspirit.memberrank.command.entity.MemberRank;
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class ResponseRankDTO {
+    private List<ResponseMountainRankDTO> modifyRanks;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/service/ClimbHistoryServiceImpl.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/climbhistory/command/service/ClimbHistoryServiceImpl.java
@@ -119,20 +119,56 @@ public class ClimbHistoryServiceImpl implements ClimbHistoryService {
             modifyStatusOfMemberDTO.setBaseMemberRanks(baseScoreMap);
             modifyStatusOfMemberDTO.setCumId(request.getCumId());
 
-            //메모. 7.등급 기준 체크, 등급 업 할 등급 코드 반환
+            //메모. 6.등급 기준 체크, 등급 업 할 등급 코드 반환
             ResponseStatusDTO responseStatusDTO = memberService.modifyStatusAfterClimbMountian(modifyStatusOfMemberDTO);
 
 
-            //메모. 10.회원 테이블 등산 횟수 , 점수 ,등급 update
-
-
-            //메모. 11.반환 할 데이터
-            findClimbCheckDTO = modelMapper.map(findClimbCheckQueryDTO, FindClimbCheckDTO.class);
-            findClimbCheckDTO.setStateCode("Y");
-            findClimbCheckDTO.setEndTime(completeTime);
+            //메모. 7.반환 할 데이터
+            //메모. 7-1. 등산 히스토리 , 산, 코스 정보
+            findClimbCheckDTO = registResponseDTO(request, findClimbCheckQueryDTO, completeTime, stampDTO, responseRankDTO, responseStatusDTO);
         } else {
         }
 
+        return findClimbCheckDTO;
+    }
+
+    private FindClimbCheckDTO registResponseDTO(RequestSubmmitClimbMountainDTO request, FindClimbCheckQueryDTO findClimbCheckQueryDTO, LocalDateTime completeTime, StampWithCourseAndMountainDTO stampDTO, ResponseRankDTO responseRankDTO, ResponseStatusDTO responseStatusDTO) {
+        FindClimbCheckDTO findClimbCheckDTO;
+        findClimbCheckDTO = modelMapper.map(findClimbCheckQueryDTO, FindClimbCheckDTO.class);
+        findClimbCheckDTO.setStateCode("Y");
+        findClimbCheckDTO.setEndTime(completeTime);
+        findClimbCheckDTO.setCumId(request.getCumId());
+        findClimbCheckDTO.setFrtrlId(request.getFrtrlId());
+        findClimbCheckDTO.setPoiId(request.getPoiId());
+
+        //메모. 7-2. 스탬프 정보
+        findClimbCheckDTO.setGetMountainStamp(stampDTO.isNewMountainStamp());
+        findClimbCheckDTO.setGetCourseStamp(stampDTO.isNewCourseStamp());
+        findClimbCheckDTO.setMountainStampImagePath(stampDTO.getMountainStampImagePath());
+        findClimbCheckDTO.setCourseStampImagePath(stampDTO.getCourseStampImagePath());
+
+        //메모. 7-3. 산별 등급 정보
+        findClimbCheckDTO.setModifyMyMountainRank(responseRankDTO.isModifyMyMountainRank());
+        findClimbCheckDTO.setModifyRanks(responseRankDTO.getModifyRanks());
+
+        //메모. 7-4. 회원 흭득 점수 및 회원 변경 정보
+        findClimbCheckDTO.setSummaryScore(responseRankDTO.getSummaryScore());
+        findClimbCheckDTO.setMemRankId(responseStatusDTO.getMemRankId());
+        findClimbCheckDTO.setCumNm(responseStatusDTO.getCumNm());
+
+        String memRankNm = "";
+        if (responseRankDTO.getBaseMemberRanks().stream()
+                .filter(x -> x.getId().equals(responseStatusDTO.getMemRankId()))
+                .findFirst()
+                .orElse(null) != null) {
+
+            memRankNm = responseRankDTO.getBaseMemberRanks().stream()
+                    .filter(x -> x.getId().equals(responseStatusDTO.getMemRankId()))
+                    .findFirst()
+                    .orElse(null).getName();
+        }
+
+        findClimbCheckDTO.setMemRankNm(memRankNm);
         return findClimbCheckDTO;
     }
 

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/controller/MemberController.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.bughunters.mountainspirit.member.command.controller;
 
 import com.bughunters.mountainspirit.common.ResponseMessage;
 import com.bughunters.mountainspirit.member.command.dto.RequestMemberDTO;
+import com.bughunters.mountainspirit.member.command.dto.RequestQuitMemberDTO;
+import com.bughunters.mountainspirit.member.command.dto.ResponseQuitDTO;
 import com.bughunters.mountainspirit.member.command.dto.ResponseSignUpDTO;
 import com.bughunters.mountainspirit.member.command.entity.Member;
 import com.bughunters.mountainspirit.member.command.service.MemberService;
@@ -50,7 +52,6 @@ public class MemberController {
                 responseMessage.setMessage("회원가입이 완료 되었습니다.");
             }
 
-
             if (!responseMap.isEmpty())
                 responseMessage.setResult(responseMap);
 
@@ -63,5 +64,26 @@ public class MemberController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(responseMessage);
         }
+    }
+
+    @DeleteMapping("/member")
+    public ResponseEntity<ResponseMessage> deleteMember(@RequestBody RequestQuitMemberDTO member) {
+        ResponseQuitDTO responseQuitDTO = memberService.memberQuit(member);
+        ResponseMessage responseMessage = new ResponseMessage();
+
+        if (responseQuitDTO == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        if (responseQuitDTO.isInvalidPwd()) {
+            responseMessage.setMessage("암호가 틀렸습니다.");
+        } else {
+            responseMessage.setMessage("회원 탈퇴가 완료 됐습니다.");
+        }
+
+        responseMessage.setHttpStatus(HttpStatus.OK.value());
+
+        return ResponseEntity.ok()
+                .body(responseMessage);
     }
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/RequestMemberDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/RequestMemberDTO.java
@@ -1,0 +1,24 @@
+package com.bughunters.mountainspirit.member.command.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+public class RequestMemberDTO {
+
+    private Long id;
+    private String memId;
+    private String email;
+    private String nickname;
+    private String memPwd;
+    private String memName;
+    private LocalDate birth;
+    private String gender;
+    private LocalDate signInDate;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/RequestQuitMemberDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/RequestQuitMemberDTO.java
@@ -1,0 +1,24 @@
+package com.bughunters.mountainspirit.member.command.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+public class RequestMemberDTO {
+
+    private Long id;
+    private String memId;
+    private String email;
+    private String nickname;
+    private String memPwd;
+    private String memName;
+    private LocalDate birth;
+    private String gender;
+    private LocalDate signInDate;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/RequestQuitMemberDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/RequestQuitMemberDTO.java
@@ -2,7 +2,6 @@ package com.bughunters.mountainspirit.member.command.dto;
 
 import lombok.*;
 
-import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -10,15 +9,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @ToString
 @Builder
-public class RequestMemberDTO {
-
+public class RequestQuitMemberDTO {
     private Long id;
-    private String memId;
-    private String email;
-    private String nickname;
     private String memPwd;
-    private String memName;
-    private LocalDate birth;
-    private String gender;
-    private LocalDate signInDate;
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseMemberDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseMemberDTO.java
@@ -1,0 +1,23 @@
+package com.bughunters.mountainspirit.member.command.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+public class ResponseMemberDTO {
+
+    private Long id;
+    private String memId;
+    private String email;
+    private String nickname;
+    private String memName;
+    private LocalDate birth;
+    private String gender;
+    private LocalDate signInDate;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseQuitDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseQuitDTO.java
@@ -1,0 +1,4 @@
+package com.bughunters.mountainspirit.member.command.dto;
+
+public class ResponseQuitDTO {
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseQuitDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseQuitDTO.java
@@ -1,4 +1,15 @@
 package com.bughunters.mountainspirit.member.command.dto;
 
+import lombok.*;
+
+
+@Setter
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+@ToString
+@Builder
 public class ResponseQuitDTO {
+    private boolean isQuit;
+    private boolean isInvalidPwd;
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseSignUpDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseSignUpDTO.java
@@ -1,0 +1,18 @@
+package com.bughunters.mountainspirit.member.command.dto;
+
+import com.bughunters.mountainspirit.member.query.dto.BlackListDTO;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ResponseSignUpDTO {
+
+    private boolean isDuplicateEmail; // 중복된 이메일 존재
+    private boolean isExistingMember; // 이미 가입된 회원
+    private boolean isBanMember; //블랙리스트 회원
+    private BlackListDTO blackListDTO;
+    private ResponseMemberDTO memberDTO;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseStatusDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/dto/ResponseStatusDTO.java
@@ -11,4 +11,6 @@ import java.util.List;
 public class ResponseStatusDTO {
     private int score;
     private boolean modifyMemberRank;
+    private long memRankId;
+    private String cumNm;
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/AuthorityList.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/AuthorityList.java
@@ -1,0 +1,25 @@
+package com.bughunters.mountainspirit.member.command.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "AuthorityList")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class AuthorityList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "authName", nullable = false)
+    private String authName;
+
+    @Column(name = "authDescribe")
+    private String authDescribe;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/LoginFailureRecord.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/LoginFailureRecord.java
@@ -1,0 +1,32 @@
+package com.bughunters.mountainspirit.member.command.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "LoginFailureRecord")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class LoginFailureRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "date", nullable = false)
+    private LocalDateTime date;
+
+    @Column(name = "ip")
+    private String ip;
+
+    @Column(name = "reason", nullable = false, length = 2000)
+    private String reason;
+
+    @Column(name = "cumId", nullable = false)
+    private Long cumId;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/LoginRecord.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/LoginRecord.java
@@ -1,0 +1,32 @@
+package com.bughunters.mountainspirit.member.command.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "LoginRecord")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class LoginRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "date", nullable = false)
+    private LocalDateTime date;
+
+    @Column(name = "ip")
+    private String ip;
+
+    @Column(name = "preAddr", nullable = false)
+    private String preAddr;
+
+    @Column(name = "cumId", nullable = false)
+    private Long cumId;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/Member.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/Member.java
@@ -44,10 +44,10 @@ public class Member {
     @Column(name = "signInDate", nullable = false)
     private LocalDate signInDate;
 
-    @Column(name = "lastLogin", nullable = false)
+    @Column(name = "lastLogin")
     private LocalDateTime lastLogin;
 
-    @Column(name = "climbCnt", nullable = false)
+    @Column(name = "climbCnt", nullable = false, insertable = false, updatable = true)
     private Long climbCnt;
 
     @Column(name = "banCnt")
@@ -59,10 +59,10 @@ public class Member {
     @Column(name = "quitDate")
     private LocalDateTime quitDate;
 
-    @Column(name = "loginLockUntil", nullable = false)
+    @Column(name = "loginLockUntil")
     private LocalDateTime loginLockUntil;
 
-    @Column(name = "score", nullable = false)
+    @Column(name = "score", nullable = false, insertable = false, updatable = true)
     private Integer score;
 
     @Column(name = "memRankId")

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/MemberAuthority.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/MemberAuthority.java
@@ -1,0 +1,25 @@
+package com.bughunters.mountainspirit.member.command.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "MemberAuthority")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MemberAuthority {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "cumId", nullable = false)
+    private Long cumId;
+
+    @Column(name = "authId")
+    private Long authId;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/MemberStatus.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/entity/MemberStatus.java
@@ -1,0 +1,22 @@
+package com.bughunters.mountainspirit.member.command.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "MemberStatus")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MemberStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/repository/MemberRepository.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package com.bughunters.mountainspirit.member.command.repository;
 import com.bughunters.mountainspirit.member.command.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Member findByEmailOrMemNameAndBirth(String email, String memName, LocalDate birth);
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberService.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.bughunters.mountainspirit.member.command.service;
 
+import com.bughunters.mountainspirit.member.command.dto.RequestMemberDTO;
 import com.bughunters.mountainspirit.member.command.dto.RequestModifyStatusOfMemberDTO;
+import com.bughunters.mountainspirit.member.command.dto.ResponseSignUpDTO;
 import com.bughunters.mountainspirit.member.command.dto.ResponseStatusDTO;
 import com.bughunters.mountainspirit.member.command.entity.Member;
 
@@ -10,4 +12,6 @@ public interface MemberService {
     Member getTest(Long id);
 
     void setMemberCrewId(Long cumId, Long crewId);
+
+    ResponseSignUpDTO signUp(RequestMemberDTO member);
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberService.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.bughunters.mountainspirit.member.command.service;
 
-import com.bughunters.mountainspirit.member.command.dto.RequestMemberDTO;
-import com.bughunters.mountainspirit.member.command.dto.RequestModifyStatusOfMemberDTO;
-import com.bughunters.mountainspirit.member.command.dto.ResponseSignUpDTO;
-import com.bughunters.mountainspirit.member.command.dto.ResponseStatusDTO;
+import com.bughunters.mountainspirit.member.command.dto.*;
 import com.bughunters.mountainspirit.member.command.entity.Member;
 
 public interface MemberService {
@@ -14,4 +11,6 @@ public interface MemberService {
     void setMemberCrewId(Long cumId, Long crewId);
 
     ResponseSignUpDTO signUp(RequestMemberDTO member);
+
+    ResponseQuitDTO memberQuit(RequestQuitMemberDTO member);
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberServiceImpl.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberServiceImpl.java
@@ -1,26 +1,35 @@
 package com.bughunters.mountainspirit.member.command.service;
 
-import com.bughunters.mountainspirit.member.command.dto.RequestModifyStatusOfMemberDTO;
-import com.bughunters.mountainspirit.member.command.dto.ResponseStatusDTO;
+import com.bughunters.mountainspirit.member.command.dto.*;
 import com.bughunters.mountainspirit.member.command.entity.Member;
 import com.bughunters.mountainspirit.member.command.repository.MemberRepository;
+import com.bughunters.mountainspirit.member.query.dto.BlackListDTO;
+import com.bughunters.mountainspirit.member.query.service.MemberQueryService;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
-public class MemberServiceImpl implements MemberService{
+public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberQueryService memberQueryService;
+    private final ModelMapper modelMapper;
 
-    public MemberServiceImpl(MemberRepository memberRepository) {
+    public MemberServiceImpl(MemberRepository memberRepository
+            , MemberQueryService memberQueryService
+            , ModelMapper modelMapper) {
         this.memberRepository = memberRepository;
+        this.memberQueryService = memberQueryService;
+        this.modelMapper = modelMapper;
     }
 
     @Override
     public ResponseStatusDTO modifyStatusAfterClimbMountian(RequestModifyStatusOfMemberDTO modifyStatusOfMemberDTO) {
         Member member = memberRepository.findById(modifyStatusOfMemberDTO.getCumId()).orElse(null);
 
-        if(member == null)
-        {
+        if (member == null) {
             throw new IllegalStateException("Member not found");
         }
         Long previousRankId = member.getMemRankId() == null ? 0 : member.getMemRankId();
@@ -50,7 +59,7 @@ public class MemberServiceImpl implements MemberService{
         responseStatusDTO.setCumNm(member.getMemName());
 
         // 등급업으로 프론트에 변경 됐다는것을 알리기 위함
-        if(!previousRankId.equals(member.getMemRankId())){
+        if (!previousRankId.equals(member.getMemRankId())) {
             responseStatusDTO.setModifyMemberRank(true);
         }
 
@@ -69,10 +78,62 @@ public class MemberServiceImpl implements MemberService{
     public void setMemberCrewId(Long cumId, Long crewId) {
         Member member = memberRepository.findById(cumId).orElse(null);
 
-        if(member == null){
+        if (member == null) {
             throw new NullPointerException("Member not found");
         }
 
         member.setCrewId(crewId);
+    }
+
+    //회원 가입
+    @Override
+    public ResponseSignUpDTO signUp(RequestMemberDTO member) {
+
+
+        return checkBeforeSignUp(member);
+    }
+
+    // 회원 가입 제한 사항 확인, 이메일 중복, 이미 가입한 회원, 블랙리스트 등등
+    private ResponseSignUpDTO checkBeforeSignUp(RequestMemberDTO memberDTO) throws IllegalArgumentException {
+
+        ResponseSignUpDTO responseSignUpDTO = new ResponseSignUpDTO();
+        // 중복된 email 혹은 이미 가입된 회원이 있는지조회(이미 가입된 회원 조건은 이름 && 생일이 같은 사람이있는지로 판단)
+        Member findMember
+                = memberRepository.findByEmailOrMemNameAndBirth(memberDTO.getEmail(), memberDTO.getMemName(), memberDTO.getBirth());
+
+        if (findMember != null) {
+            //중복 이메일이 있는지 확인
+            if (findMember.getEmail().equals(memberDTO.getEmail())) {
+                responseSignUpDTO.setDuplicateEmail(true);
+                return responseSignUpDTO;
+            }
+
+            if (findMember != null) {
+                BlackListDTO blackListDTO = memberQueryService.findBlakListByMemberId(findMember.getId());
+
+                // null이 아니면 블랙리스트라 가입 거절
+                if (blackListDTO != null) {
+                    responseSignUpDTO.setBanMember(true);
+                    responseSignUpDTO.setBlackListDTO(blackListDTO);
+                    return responseSignUpDTO;
+                }
+
+                responseSignUpDTO.setExistingMember(true);
+                return responseSignUpDTO;
+            }
+
+        } else {
+            try {
+                Member member = modelMapper.map(memberDTO, Member.class);
+                member.setMemStsId(1L); //회원 상태 정상 상태로 초기 셋팅
+                member.setSignInDate(LocalDate.now());
+                member = memberRepository.save(member);
+                responseSignUpDTO.setMemberDTO(modelMapper.map(member, ResponseMemberDTO.class));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Member not Exception");
+            }
+        }
+
+        return responseSignUpDTO;
     }
 }

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberServiceImpl.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 public class MemberServiceImpl implements MemberService {
@@ -91,6 +92,28 @@ public class MemberServiceImpl implements MemberService {
 
 
         return checkBeforeSignUp(member);
+    }
+
+    @Override
+    public ResponseQuitDTO memberQuit(RequestQuitMemberDTO memberDTO) {
+        ResponseQuitDTO responseQuitDTO = new ResponseQuitDTO();
+        Member member = memberRepository.findById(memberDTO.getId()).orElse(null);
+
+        if (member == null) { //테스트중에는 값을 잘못 입력해서 null 이 나올수 있어서 처리 함.
+            return null;
+        }
+
+        //암호가 틀렸을 때
+        if (!member.getMemPwd().equals(memberDTO.getMemPwd())) {
+            responseQuitDTO.setInvalidPwd(true);
+            return responseQuitDTO;
+        }
+
+        member.setQuitDate(LocalDateTime.now());
+        member.setMemStsId(2L);
+        memberRepository.save(member);
+
+        return responseQuitDTO;
     }
 
     // 회원 가입 제한 사항 확인, 이메일 중복, 이미 가입한 회원, 블랙리스트 등등

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberServiceImpl.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/command/service/MemberServiceImpl.java
@@ -46,8 +46,11 @@ public class MemberServiceImpl implements MemberService{
 
         ResponseStatusDTO responseStatusDTO = new ResponseStatusDTO();
         responseStatusDTO.setScore(score);
+        responseStatusDTO.setMemRankId(findRankId);
+        responseStatusDTO.setCumNm(member.getMemName());
+
         // 등급업으로 프론트에 변경 됐다는것을 알리기 위함
-        if(previousRankId.equals(member.getMemRankId())){
+        if(!previousRankId.equals(member.getMemRankId())){
             responseStatusDTO.setModifyMemberRank(true);
         }
 

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/dto/BlackListDTO.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/dto/BlackListDTO.java
@@ -1,0 +1,17 @@
+package com.bughunters.mountainspirit.member.query.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class BlackListDTO {
+    private Long id;
+    private LocalDateTime createDate;
+    private Long adminId;
+    private Long memberId;
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/mapper/MemberQueryRepository.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/mapper/MemberQueryRepository.java
@@ -1,0 +1,9 @@
+package com.bughunters.mountainspirit.member.query.mapper;
+
+import com.bughunters.mountainspirit.member.query.dto.BlackListDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MemberQueryRepository {
+    BlackListDTO selectBlackListByMember(Long id);
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/service/MemberQueryService.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/service/MemberQueryService.java
@@ -1,0 +1,7 @@
+package com.bughunters.mountainspirit.member.query.service;
+
+import com.bughunters.mountainspirit.member.query.dto.BlackListDTO;
+
+public interface MemberQueryService {
+    BlackListDTO findBlakListByMemberId(Long id);
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/service/MemberQueryServiceImpl.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/member/query/service/MemberQueryServiceImpl.java
@@ -1,0 +1,19 @@
+package com.bughunters.mountainspirit.member.query.service;
+
+import com.bughunters.mountainspirit.member.query.dto.BlackListDTO;
+import com.bughunters.mountainspirit.member.query.mapper.MemberQueryRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberQueryServiceImpl implements MemberQueryService{
+    private final MemberQueryRepository memberQueryRepository;
+
+    public MemberQueryServiceImpl(MemberQueryRepository memberQueryRepository) {
+        this.memberQueryRepository = memberQueryRepository;
+    }
+
+    @Override
+    public BlackListDTO findBlakListByMemberId(Long id) {
+        return memberQueryRepository.selectBlackListByMember(id);
+    }
+}

--- a/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/memberrank/command/service/MemberRankServiceImpl.java
+++ b/1_CodeSoruce/src/main/java/com/bughunters/mountainspirit/memberrank/command/service/MemberRankServiceImpl.java
@@ -155,7 +155,8 @@ public class MemberRankServiceImpl implements MemberRankService {
                     memberRankQueryService.selectLotsOfClimbingByMountain(requestRankDTO.getFrtrlId());
 
             // 산 도장이 있고 내가 가장 많은 등산 횟수 보유자
-            if (higherClimbers.get(0).getCumId().equals(requestRankDTO.getCumId())) {
+            if (higherClimbers.get(0).getCumId().equals(requestRankDTO.getCumId())
+            && myRank.getMtRankId() != maxRank) {
 
                 myRank.setMtRankId(maxRank);
                 //산신령 등급으로 등급 업

--- a/1_CodeSoruce/src/main/resources/com/bughunters/mountainspirit/member/query/mapper/MemberQueryRepository.xml
+++ b/1_CodeSoruce/src/main/resources/com/bughunters/mountainspirit/member/query/mapper/MemberQueryRepository.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.bughunters.mountainspirit.member.query.mapper.MemberQueryRepository">
+    <resultMap id="blackListResultMap" type="com.bughunters.mountainspirit.member.query.dto.BlackListDTO">
+        <id property="id" column="id"/>
+        <result property="createDate" column="createDate"/>
+        <result property="adminId" column="adminId"/>
+        <result property="memberId" column="memberId"/>
+    </resultMap>
+
+    <select id="selectBlackListByMember" parameterType="_long" resultMap="blackListResultMap">
+        SELECT
+               a.id
+             , a.createDate
+             , a.adminId
+             , a.memberId
+          FROM Blacklist a
+         WHERE a.memberId = #{id}
+    </select>
+</mapper>

--- a/2_DDL/DDL.sql
+++ b/2_DDL/DDL.sql
@@ -26,6 +26,7 @@ DROP TABLE IF EXISTS CrewClimbRecord;
 DROP TABLE IF EXISTS CrewMemberRole;
 DROP TABLE IF EXISTS CrewMemberHistory;
 DROP TABLE IF EXISTS CrewRankStandard;
+DROP TABLE IF EXISTS CrewMemberAuth;
 
 DROP TABLE IF EXISTS Mountain;
 DROP TABLE IF EXISTS MountainImage;
@@ -72,7 +73,8 @@ CREATE TABLE Member (
 	memStsId	bigint	NULL,
 	crewId	bigint	NULL	,
 	constraint pk_Member_id primary key(id),
-	constraint ch_Member_gender check(gender in('F','M'))
+	constraint ch_Member_gender check(gender in('F','M')),
+	constraint uk_Member_email Unique(email)
 );
 
 CREATE TABLE ScoreStandard (
@@ -307,9 +309,16 @@ CREATE TABLE IF NOT EXISTS CrewClimbRecord
 CREATE TABLE IF NOT EXISTS CrewMemberRole
 (
     id           BIGINT AUTO_INCREMENT       NOT NULL,
-    crewRoleName VARCHAR(255) NULL,
-    crewRoleAuth VARCHAR(255) NULL,
+    crewRoleName VARCHAR(255) NULL
     CONSTRAINT pk_CrewMemberRole_id PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS CrewMemberAuth
+(
+    id           BIGINT AUTO_INCREMENT NOT NULL,
+    crewRoleAuth VARCHAR(255)          NOT NULL,
+    crewRoleId   BIGINT                NOT NULL,
+    CONSTRAINT pk_CrewMemberAuth_id PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS CrewMemberHistory
@@ -659,6 +668,9 @@ ALTER TABLE CrewClimbRecord
     ADD CONSTRAINT fk_CrewClimbRecord_CrewClimbBoard_crewClimbId FOREIGN KEY (crewClimbId) REFERENCES CrewClimbBoard (id),
     ADD CONSTRAINT fk_CrewClimbRecord_Mountain_frtrlId FOREIGN KEY (frtrlId) REFERENCES Mountain (frtrlId),
     ADD CONSTRAINT fk_CrewClimbRecord_CrewMember_crewMemberId FOREIGN KEY (crewMemberId) REFERENCES CrewMember (id) ON DELETE SET NULL;
+
+ALTER TABLE CrewMemberAuth
+    ADD CONSTRAINT fk_CrewMemberAuth_CrewMemberRole_crewRoleId FOREIGN KEY (crewRoleId) REFERENCES CrewMemberRole (id);
 
 
 ALTER TABLE MountainImage ADD CONSTRAINT fk_MountainImage_Mountain_frtrlId 


### PR DESCRIPTION
## 🔎 작업 내용
- 회원 탈퇴 ,  가입 기능 개발

## ➕ 이슈 링크
- #61 

### 1. 회원 가입
- 이미 있는 회원정보, 중복 이메일, 필수 입력 항목 누락, 블랙리스트 회원 체크 후 모두 통과하면 회원 가입진행
- 이미 가입된 회원은(이름 & 생년월일 이 동일 할 경우 동일 인물로 판단)

1. 이미 가입된 회원
<img width="884" height="272" alt="image" src="https://github.com/user-attachments/assets/380b125e-0d45-4c5b-a35b-01a9df37011f" />

2. 필수 입력 정보 누락
<img width="829" height="247" alt="image" src="https://github.com/user-attachments/assets/a545eec0-d69f-4e9a-a981-de2580d60d1c" />

3. 블랙리스트 회원
<img width="772" height="288" alt="image" src="https://github.com/user-attachments/assets/552e6a35-7aed-4cce-b7b4-ba6e3a780273" />

4. 정상 가입
<img width="821" height="366" alt="image" src="https://github.com/user-attachments/assets/e765144f-b4fe-4961-b95f-86041bf99050" />



### 2. 회원 탈퇴
- 회원 탈퇴 회원 status 를 회원 탈퇴 상태로 변경
<img width="837" height="188" alt="image" src="https://github.com/user-attachments/assets/c1ae9b88-76c0-463e-acc3-36ab43d6293a" />
<img width="481" height="47" alt="image" src="https://github.com/user-attachments/assets/2f7a8802-afed-473c-8bbd-4ec711d0427f" />
